### PR TITLE
feat(eval): port usdx-autochart evaluation harness (time-domain scoring + stage-level library replay)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ python-sidecar/output_test/
 python-sidecar/output_raimundos/
 # log de sessão do sidecar persistente (server.py), gerado em runtime
 python-sidecar/_server_session.log
+# saídas do harness de avaliação (eval/library_replay.py) - stems/caches pesados
+python-sidecar/eval_runs/
 *.wav
 *.mp3
 *.webm

--- a/python-sidecar/eval/README.md
+++ b/python-sidecar/eval/README.md
@@ -1,0 +1,56 @@
+# eval — accuracy harness against gold hand-charted songs
+
+Dev tooling only (nothing here is imported by the app runtime). Ported from
+[usdx-autochart](https://github.com/Alejololer/usdx-autochart) (MIT) and
+adapted to USKMaker's artifacts and pipeline stages. Discussed on upstream
+issue #2.
+
+## What's here
+
+| file | purpose |
+|---|---|
+| `usdx_parse.py` | UltraStar `.txt` reader (headers, notes, breaks, P1/P2 duets, cp1252 fallback). Time model: `time_s = GAP/1000 + beat*60/(BPM*4)`. Note lyrics keep their spaces — they mark word boundaries. |
+| `evaluate.py` | Time-domain scoring of a generated chart (`.txt` **or** `song_data.json`) against a gold `.txt`: note-count ratio, onset error, relative-pitch contour, lyric similarity; `--duet` scores P1/P2 per singer. |
+| `library_replay.py` | Stage-level replay of USKMaker's own stages against a local gold library: whisperx alignment (word recall/onset error, interpolated fraction, lead-vocal rescue stats), SwiftF0 pitch inside gold note bounds, BPM vs gold `#BPM` (mod octave). Resumable, per-song caching, stratified sampling. |
+| `seed_set.json` | The 7-song seed set agreed on issue #2, referenced **by name only**. |
+
+## Copyright
+
+Nothing copyrighted lives in the repo. Gold charts and audio are referenced by
+library folder name (`Artist - Title/` with `.mp3` + gold `.txt`); each dev
+supplies their own local library (`--lib`, default `D:\Canciones Karaoke`).
+
+## Usage
+
+```bash
+# score one generated song against its gold chart
+python eval/evaluate.py "New Output/Song/song_data.json" "D:/Canciones Karaoke/Artist - Title/Artist - Title.txt"
+
+# stage-level replay: stratified sample (lang x words-per-minute tercile)
+python eval/library_replay.py --n 20 --seed 0
+
+# stage-level replay: the curated seed set
+python eval/library_replay.py --seed-set eval/seed_set.json
+
+# rebuild results.csv + summary from existing per-song JSONs
+python eval/library_replay.py --n 20 --seed 0 --aggregate-only
+```
+
+Run from `python-sidecar/` with its venv. Outputs land in
+`python-sidecar/eval_runs/<run>/` (`results/*.json`, `results.csv`,
+`cache/<slug>/` with stems/alignment/pitch).
+
+## Reading the numbers
+
+- Gold onsets are themselves ~50 ms-grid quantized and stylistic —
+  differences below ~25–50 ms are noise, not signal.
+- **Demucs is nondeterministic** (randomized shifts). On repetitive songs the
+  same code can score wildly differently on two separation rolls. The replay
+  caches stems per song precisely so that A/B comparisons between code
+  versions run on **fixed stems** — never compare runs that re-separated.
+- `interp_frac` is the pipeline's internal quality signal (words whose timing
+  was interpolated, not measured); `rescue_tried/won` shows when the
+  lead-vocal rescue (main.py Etapa 4b) fired and whether it improved things —
+  the background-choir failure detector.
+- `[MULTI]` duet golds are excluded from the replay (it flattens tracks);
+  score duets end-to-end with `evaluate.py --duet`.

--- a/python-sidecar/eval/README.md
+++ b/python-sidecar/eval/README.md
@@ -9,8 +9,8 @@ issue #2.
 
 | file | purpose |
 |---|---|
-| `usdx_parse.py` | UltraStar `.txt` reader (headers, notes, breaks, P1/P2 duets, cp1252 fallback). Time model: `time_s = GAP/1000 + beat*60/(BPM*4)`. Note lyrics keep their spaces — they mark word boundaries. |
-| `evaluate.py` | Time-domain scoring of a generated chart (`.txt` **or** `song_data.json`) against a gold `.txt`: note-count ratio, onset error, relative-pitch contour, lyric similarity; `--duet` scores P1/P2 per singer. |
+| `usdx_parse.py` | UltraStar `.txt` reader (headers, notes, breaks, cp1252 fallback). P1/P2 duet blocks are flattened in time order. Time model: `time_s = GAP/1000 + beat*60/(BPM*4)`. Note lyrics keep their spaces — they mark word boundaries. |
+| `evaluate.py` | Time-domain scoring of a generated chart (`.txt` **or** `song_data.json`) against a gold `.txt`: note-count ratio, onset error, relative-pitch contour, lyric similarity. |
 | `library_replay.py` | Stage-level replay of USKMaker's own stages against a local gold library: whisperx alignment (word recall/onset error, interpolated fraction, lead-vocal rescue stats), SwiftF0 pitch inside gold note bounds, BPM vs gold `#BPM` (mod octave). Resumable, per-song caching, stratified sampling. |
 | `seed_set.json` | The 7-song seed set agreed on issue #2, referenced **by name only**. |
 
@@ -52,5 +52,10 @@ Run from `python-sidecar/` with its venv. Outputs land in
   was interpolated, not measured); `rescue_tried/won` shows when the
   lead-vocal rescue (main.py Etapa 4b) fired and whether it improved things —
   the background-choir failure detector.
-- `[MULTI]` duet golds are excluded from the replay (it flattens tracks);
-  score duets end-to-end with `evaluate.py --duet`.
+- Evaluation is **single-player only for now** — USKMaker doesn't generate
+  duets. `evaluate.py` scores a generated chart against a `[MULTI]` gold by
+  flattening both parts in time order (what one player sings covering both);
+  the replay excludes `[MULTI]` golds entirely (interleaved voices would
+  poison word matching). If duet generation lands, usdx-autochart's
+  per-singer scoring (`evaluate_duet`) can be re-ported from the same MIT
+  source.

--- a/python-sidecar/eval/evaluate.py
+++ b/python-sidecar/eval/evaluate.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+"""Score a generated chart against a reference (gold) chart.
+
+Ported from usdx-autochart (MIT, Alejololer/usdx-autochart) and adapted to
+USKMaker's artifacts: the generated side can be either a written .txt or the
+canonical ``song_data.json`` (what rust-core renders the .txt from).
+
+Everything is compared in the time domain (seconds) so that differing BPM/GAP
+choices between the two charts don't bias the result. Reports note-count ratio,
+onset-timing error on matched notes, relative-pitch contour correlation, and a
+lyric-similarity ratio. ``evaluate_duet`` scores P1/P2 charts per singer.
+
+CLI:
+    python eval/evaluate.py "New Output/Song/song_data.json" "D:/Canciones Karaoke/Artist - Title/Artist - Title.txt"
+    python eval/evaluate.py generated.txt gold.txt --duet
+"""
+from __future__ import annotations
+
+import difflib
+import json
+import re
+import statistics
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import usdx_parse
+    from usdx_parse import Chart, Line, Note, CHAR_TO_KIND
+else:
+    from . import usdx_parse
+    from .usdx_parse import Chart, Line, Note, CHAR_TO_KIND
+
+
+# ---------- loaders ----------
+
+def chart_from_song_data(data: dict) -> Chart:
+    """Build a Chart from USKMaker's ``song_data.json`` (the canonical artifact
+    the Rust core writes the .txt from). Single-track today."""
+    breaks = set(data.get("phrase_breaks_after_index") or [])
+    lines: List[Line] = []
+    cur = Line()
+    for i, n in enumerate(data.get("notes") or []):
+        cur.notes.append(Note(
+            start_beat=int(n["start_beat"]),
+            duration=int(n["duration_beats"]),
+            pitch=int(n["pitch"]),
+            text=n.get("text", ""),
+            kind=CHAR_TO_KIND.get(n.get("note_type", ":"), "normal"),
+        ))
+        if i in breaks:
+            lines.append(cur)
+            cur = Line()
+    if cur.notes:
+        lines.append(cur)
+    return Chart(
+        title=data.get("title", ""),
+        artist=data.get("artist", ""),
+        bpm=float(data["bpm"]),
+        gap_ms=float(data.get("gap_ms", 0)),
+        audio=data.get("mp3_filename", ""),
+        lines=lines,
+        language=data.get("language"),
+    )
+
+
+def interpolated_fraction(data: dict) -> Optional[float]:
+    """Fraction of song_data.json notes whose timing was interpolated (not
+    measured) - the pipeline's internal quality signal, reported as a bonus
+    metric alongside the gold comparison."""
+    notes = data.get("notes") or []
+    sourced = [n for n in notes if n.get("source")]
+    if not sourced:
+        return None
+    interp = sum(1 for n in sourced if n["source"] == "interpolated")
+    return round(interp / len(sourced), 3)
+
+
+def load_chart(path: str, *, keep_tracks: bool = False) -> Tuple[Chart, Optional[dict]]:
+    """Load a .txt chart or a song_data.json. Returns (chart, song_data|None)."""
+    if path.lower().endswith(".json"):
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        return chart_from_song_data(data), data
+    return usdx_parse.read_file(path, keep_tracks=keep_tracks), None
+
+
+# ---------- time-domain scoring (ported as-is) ----------
+
+@dataclass
+class TimedNote:
+    start: float
+    end: float
+    pitch: int
+    text: str
+
+
+def _flatten_track(track_lines, chart: Chart) -> List[TimedNote]:
+    out: List[TimedNote] = []
+    for line in track_lines:
+        for n in line.notes:
+            out.append(TimedNote(
+                chart.beat_to_time(n.start_beat),
+                chart.beat_to_time(n.start_beat + n.duration),
+                n.pitch, n.text,
+            ))
+    out.sort(key=lambda t: t.start)
+    return out
+
+
+def _flatten(chart: Chart) -> List[TimedNote]:
+    tracks = chart.tracks if chart.tracks else [chart.lines]
+    out: List[TimedNote] = []
+    for track in tracks:
+        out.extend(_flatten_track(track, chart))
+    out.sort(key=lambda t: t.start)
+    return out
+
+
+def _match(gen: List[TimedNote], ref: List[TimedNote], tol: float = 0.3):
+    """Greedy nearest-onset matching within `tol` seconds."""
+    pairs: List[Tuple[TimedNote, TimedNote]] = []
+    used = [False] * len(gen)
+    for r in ref:
+        best, bestd = -1, tol
+        for i, g in enumerate(gen):
+            if used[i]:
+                continue
+            d = abs(g.start - r.start)
+            if d < bestd:
+                best, bestd = i, d
+        if best >= 0:
+            used[best] = True
+            pairs.append((gen[best], r))
+    return pairs
+
+
+def _norm_text(notes: List[TimedNote]) -> str:
+    s = "".join(n.text for n in notes).lower()
+    return re.sub(r"\s+", " ", re.sub(r"[^\w\sáéíóúñü]", "", s)).strip()
+
+
+def _pair_metrics(gen: List[TimedNote], ref: List[TimedNote],
+                  onset_tol: float) -> dict:
+    """Core metrics for one gen<->ref note-list pairing."""
+    pairs = _match(gen, ref, onset_tol)
+    onset_err = [abs(g.start - r.start) for g, r in pairs]
+    if pairs:
+        gmed = statistics.median(g.pitch for g, _ in pairs)
+        rmed = statistics.median(r.pitch for _, r in pairs)
+        gp = np.array([g.pitch - gmed for g, _ in pairs], dtype=float)
+        rp = np.array([r.pitch - rmed for _, r in pairs], dtype=float)
+        pitch_corr = float(np.corrcoef(gp, rp)[0, 1]) if len(gp) > 1 and gp.std() and rp.std() else 0.0
+        pitch_within2 = float(np.mean(np.abs(gp - rp) <= 2))
+    else:
+        pitch_corr, pitch_within2 = 0.0, 0.0
+    # autojunk=False: difflib's popularity heuristic treats common characters
+    # in >200-char strings as junk, making ratios on full lyrics near-random
+    lyric = difflib.SequenceMatcher(None, _norm_text(gen), _norm_text(ref),
+                                    autojunk=False).ratio()
+    return {
+        "gen_notes": len(gen),
+        "ref_notes": len(ref),
+        "note_count_ratio": round(len(gen) / len(ref), 3) if ref else 0.0,
+        "matched": len(pairs),
+        "match_rate_vs_ref": round(len(pairs) / len(ref), 3) if ref else 0.0,
+        "onset_err_ms_median": round(statistics.median(onset_err) * 1000, 1) if onset_err else None,
+        "onset_err_ms_mean": round(statistics.mean(onset_err) * 1000, 1) if onset_err else None,
+        "pitch_contour_corr": round(pitch_corr, 3),
+        "pitch_within_2st_rate": round(pitch_within2, 3),
+        "lyric_similarity": round(lyric, 3),
+    }
+
+
+def evaluate(generated: Chart, reference: Chart, onset_tol: float = 0.3) -> dict:
+    gen = _flatten(generated)
+    ref = _flatten(reference)
+    out = _pair_metrics(gen, ref, onset_tol)
+    out["gen_span_s"] = round(gen[-1].end - gen[0].start, 1) if gen else 0.0
+    out["ref_span_s"] = round(ref[-1].end - ref[0].start, 1) if ref else 0.0
+    return out
+
+
+def evaluate_duet(generated: Chart, reference: Chart, onset_tol: float = 0.3) -> dict:
+    """Score a 2-track duet per singer. Tries both gen<->ref pairings, keeps the
+    one with more matched notes, and reports per-track metrics plus
+    ``singer_assignment_accuracy`` (matched ref notes whose nearest gen note lands
+    on the agreeing track). Returns ``{"duet": False}`` if either side isn't a
+    2-track duet - the caller should fall back to the flattened ``evaluate``.
+    Note: USKMaker's generated song_data.json is single-track today, so this
+    only applies to .txt-vs-.txt comparisons with P1/P2 on both sides."""
+    if not (generated.tracks and len(generated.tracks) >= 2
+            and reference.tracks and len(reference.tracks) >= 2):
+        return {"duet": False}
+
+    g = [_flatten_track(t, generated) for t in generated.tracks[:2]]
+    r = [_flatten_track(t, reference) for t in reference.tracks[:2]]
+
+    # ref-track-index -> gen-track-index for each candidate pairing
+    pairings = {"direct": {0: 0, 1: 1}, "swap": {0: 1, 1: 0}}
+
+    def total_matched(mapping) -> int:
+        return sum(len(_match(g[mapping[rt]], r[rt], onset_tol)) for rt in (0, 1))
+
+    best = max(pairings, key=lambda name: total_matched(pairings[name]))
+    mapping = pairings[best]
+
+    p1m = _pair_metrics(g[mapping[0]], r[0], onset_tol)
+    p2m = _pair_metrics(g[mapping[1]], r[1], onset_tol)
+
+    # singer-assignment accuracy: for each ref note, compare the nearest gen note
+    # on its paired track against the nearest on the other track. Correct iff the
+    # paired track is at least as close (ties -> correct, so unison/identical
+    # charts score 1.0). Notes with no gen note within tol on either track are
+    # unattributed and excluded.
+    def _nearest(track: List[TimedNote], t: float) -> Optional[float]:
+        best_d = None
+        for n in track:
+            d = abs(n.start - t)
+            if d <= onset_tol and (best_d is None or d < best_d):
+                best_d = d
+        return best_d
+
+    correct = total = 0
+    for rt in (0, 1):
+        want, other = mapping[rt], mapping[1 - rt]
+        for rn in r[rt]:
+            d_same = _nearest(g[want], rn.start)
+            d_other = _nearest(g[other], rn.start)
+            if d_same is None and d_other is None:
+                continue
+            total += 1
+            if d_same is not None and (d_other is None or d_same <= d_other):
+                correct += 1
+
+    return {
+        "duet": True,
+        "pairing": best,
+        "singer_assignment_accuracy": round(correct / total, 3) if total else 0.0,
+        "attributed_notes": total,
+        "p1": p1m,
+        "p2": p2m,
+    }
+
+
+def format_report(metrics: dict) -> str:
+    lines = ["=== generated vs reference ==="]
+    for k, v in metrics.items():
+        lines.append(f"  {k:24s}: {v}")
+    return "\n".join(lines)
+
+
+def format_report_duet(metrics: dict) -> str:
+    if not metrics.get("duet"):
+        return "(not a 2-track duet on both sides; flattened score applies)"
+    lines = ["=== generated vs reference (per-singer) ==="]
+    for k in ("pairing", "singer_assignment_accuracy", "attributed_notes"):
+        lines.append(f"  {k:28s}: {metrics[k]}")
+    for trk in ("p1", "p2"):
+        lines.append(f"  [{trk.upper()}]")
+        for k, v in metrics[trk].items():
+            lines.append(f"    {k:26s}: {v}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    import argparse
+    ap = argparse.ArgumentParser(description="Score a generated chart (.txt or song_data.json) against a gold .txt")
+    ap.add_argument("generated")
+    ap.add_argument("gold")
+    ap.add_argument("--tol", type=float, default=0.3, help="onset match tolerance in seconds")
+    ap.add_argument("--duet", action="store_true", help="also score per-singer (both sides must have P1/P2 tracks)")
+    ap.add_argument("--json", dest="json_out", default=None, help="also write metrics to this JSON file")
+    args = ap.parse_args()
+
+    gen_chart, song_data = load_chart(args.generated, keep_tracks=args.duet)
+    gold_chart, _ = load_chart(args.gold, keep_tracks=args.duet)
+
+    metrics = evaluate(gen_chart, gold_chart, args.tol)
+    if song_data is not None:
+        metrics["gen_interpolated_frac"] = interpolated_fraction(song_data)
+    print(format_report(metrics))
+
+    if args.duet:
+        duet = evaluate_duet(gen_chart, gold_chart, args.tol)
+        metrics["duet"] = duet
+        print(format_report_duet(duet))
+
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8") as f:
+            json.dump(metrics, f, ensure_ascii=False, indent=1)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python-sidecar/eval/evaluate.py
+++ b/python-sidecar/eval/evaluate.py
@@ -8,11 +8,17 @@ canonical ``song_data.json`` (what rust-core renders the .txt from).
 Everything is compared in the time domain (seconds) so that differing BPM/GAP
 choices between the two charts don't bias the result. Reports note-count ratio,
 onset-timing error on matched notes, relative-pitch contour correlation, and a
-lyric-similarity ratio. ``evaluate_duet`` scores P1/P2 charts per singer.
+lyric-similarity ratio.
+
+Scope: single-player evaluation only, matching what USKMaker generates today
+(single-track charts). Gold [MULTI] duets are flattened by the parser - both
+parts merged in time order, which is exactly what a single player sings when
+covering both - and scored with the same metrics. If duet generation lands
+later, usdx-autochart's per-singer scoring (``evaluate_duet``: track pairing +
+singer-assignment accuracy) can be re-ported from the same MIT source.
 
 CLI:
     python eval/evaluate.py "New Output/Song/song_data.json" "D:/Canciones Karaoke/Artist - Title/Artist - Title.txt"
-    python eval/evaluate.py generated.txt gold.txt --duet
 """
 from __future__ import annotations
 
@@ -80,13 +86,13 @@ def interpolated_fraction(data: dict) -> Optional[float]:
     return round(interp / len(sourced), 3)
 
 
-def load_chart(path: str, *, keep_tracks: bool = False) -> Tuple[Chart, Optional[dict]]:
+def load_chart(path: str) -> Tuple[Chart, Optional[dict]]:
     """Load a .txt chart or a song_data.json. Returns (chart, song_data|None)."""
     if path.lower().endswith(".json"):
         with open(path, encoding="utf-8") as f:
             data = json.load(f)
         return chart_from_song_data(data), data
-    return usdx_parse.read_file(path, keep_tracks=keep_tracks), None
+    return usdx_parse.read_file(path), None
 
 
 # ---------- time-domain scoring (ported as-is) ----------
@@ -99,24 +105,15 @@ class TimedNote:
     text: str
 
 
-def _flatten_track(track_lines, chart: Chart) -> List[TimedNote]:
+def _flatten(chart: Chart) -> List[TimedNote]:
     out: List[TimedNote] = []
-    for line in track_lines:
+    for line in chart.lines:
         for n in line.notes:
             out.append(TimedNote(
                 chart.beat_to_time(n.start_beat),
                 chart.beat_to_time(n.start_beat + n.duration),
                 n.pitch, n.text,
             ))
-    out.sort(key=lambda t: t.start)
-    return out
-
-
-def _flatten(chart: Chart) -> List[TimedNote]:
-    tracks = chart.tracks if chart.tracks else [chart.lines]
-    out: List[TimedNote] = []
-    for track in tracks:
-        out.extend(_flatten_track(track, chart))
     out.sort(key=lambda t: t.start)
     return out
 
@@ -185,85 +182,10 @@ def evaluate(generated: Chart, reference: Chart, onset_tol: float = 0.3) -> dict
     return out
 
 
-def evaluate_duet(generated: Chart, reference: Chart, onset_tol: float = 0.3) -> dict:
-    """Score a 2-track duet per singer. Tries both gen<->ref pairings, keeps the
-    one with more matched notes, and reports per-track metrics plus
-    ``singer_assignment_accuracy`` (matched ref notes whose nearest gen note lands
-    on the agreeing track). Returns ``{"duet": False}`` if either side isn't a
-    2-track duet - the caller should fall back to the flattened ``evaluate``.
-    Note: USKMaker's generated song_data.json is single-track today, so this
-    only applies to .txt-vs-.txt comparisons with P1/P2 on both sides."""
-    if not (generated.tracks and len(generated.tracks) >= 2
-            and reference.tracks and len(reference.tracks) >= 2):
-        return {"duet": False}
-
-    g = [_flatten_track(t, generated) for t in generated.tracks[:2]]
-    r = [_flatten_track(t, reference) for t in reference.tracks[:2]]
-
-    # ref-track-index -> gen-track-index for each candidate pairing
-    pairings = {"direct": {0: 0, 1: 1}, "swap": {0: 1, 1: 0}}
-
-    def total_matched(mapping) -> int:
-        return sum(len(_match(g[mapping[rt]], r[rt], onset_tol)) for rt in (0, 1))
-
-    best = max(pairings, key=lambda name: total_matched(pairings[name]))
-    mapping = pairings[best]
-
-    p1m = _pair_metrics(g[mapping[0]], r[0], onset_tol)
-    p2m = _pair_metrics(g[mapping[1]], r[1], onset_tol)
-
-    # singer-assignment accuracy: for each ref note, compare the nearest gen note
-    # on its paired track against the nearest on the other track. Correct iff the
-    # paired track is at least as close (ties -> correct, so unison/identical
-    # charts score 1.0). Notes with no gen note within tol on either track are
-    # unattributed and excluded.
-    def _nearest(track: List[TimedNote], t: float) -> Optional[float]:
-        best_d = None
-        for n in track:
-            d = abs(n.start - t)
-            if d <= onset_tol and (best_d is None or d < best_d):
-                best_d = d
-        return best_d
-
-    correct = total = 0
-    for rt in (0, 1):
-        want, other = mapping[rt], mapping[1 - rt]
-        for rn in r[rt]:
-            d_same = _nearest(g[want], rn.start)
-            d_other = _nearest(g[other], rn.start)
-            if d_same is None and d_other is None:
-                continue
-            total += 1
-            if d_same is not None and (d_other is None or d_same <= d_other):
-                correct += 1
-
-    return {
-        "duet": True,
-        "pairing": best,
-        "singer_assignment_accuracy": round(correct / total, 3) if total else 0.0,
-        "attributed_notes": total,
-        "p1": p1m,
-        "p2": p2m,
-    }
-
-
 def format_report(metrics: dict) -> str:
     lines = ["=== generated vs reference ==="]
     for k, v in metrics.items():
         lines.append(f"  {k:24s}: {v}")
-    return "\n".join(lines)
-
-
-def format_report_duet(metrics: dict) -> str:
-    if not metrics.get("duet"):
-        return "(not a 2-track duet on both sides; flattened score applies)"
-    lines = ["=== generated vs reference (per-singer) ==="]
-    for k in ("pairing", "singer_assignment_accuracy", "attributed_notes"):
-        lines.append(f"  {k:28s}: {metrics[k]}")
-    for trk in ("p1", "p2"):
-        lines.append(f"  [{trk.upper()}]")
-        for k, v in metrics[trk].items():
-            lines.append(f"    {k:26s}: {v}")
     return "\n".join(lines)
 
 
@@ -273,22 +195,16 @@ def main() -> int:
     ap.add_argument("generated")
     ap.add_argument("gold")
     ap.add_argument("--tol", type=float, default=0.3, help="onset match tolerance in seconds")
-    ap.add_argument("--duet", action="store_true", help="also score per-singer (both sides must have P1/P2 tracks)")
     ap.add_argument("--json", dest="json_out", default=None, help="also write metrics to this JSON file")
     args = ap.parse_args()
 
-    gen_chart, song_data = load_chart(args.generated, keep_tracks=args.duet)
-    gold_chart, _ = load_chart(args.gold, keep_tracks=args.duet)
+    gen_chart, song_data = load_chart(args.generated)
+    gold_chart, _ = load_chart(args.gold)
 
     metrics = evaluate(gen_chart, gold_chart, args.tol)
     if song_data is not None:
         metrics["gen_interpolated_frac"] = interpolated_fraction(song_data)
     print(format_report(metrics))
-
-    if args.duet:
-        duet = evaluate_duet(gen_chart, gold_chart, args.tol)
-        metrics["duet"] = duet
-        print(format_report_duet(duet))
 
     if args.json_out:
         with open(args.json_out, "w", encoding="utf-8") as f:

--- a/python-sidecar/eval/library_replay.py
+++ b/python-sidecar/eval/library_replay.py
@@ -1,0 +1,614 @@
+# -*- coding: utf-8 -*-
+"""Stage-level eval harness: score USKMaker's pipeline stages *independently*
+against gold hand-charted UltraStar songs from a local library, instead of only
+comparing final output (that's eval/evaluate.py's job).
+
+Ported from usdx-autochart (MIT, Alejololer/usdx-autochart) with the stages
+swapped for USKMaker's own (python-sidecar/pipeline/):
+
+  align : align.align_lyrics_to_audio on the cached Demucs vocal stem, with
+          lyrics extracted from the gold chart -> word recall + onset/end error
+          vs the gold word times, plus the interpolated-word fraction and
+          whether the lead-vocal rescue (main.py "Etapa 4b") fired/won -
+          the background-choir failure detector.
+  pitch : SwiftF0 voiced-median MIDI inside *gold* note boundaries vs gold
+          pitch, relative (medians subtracted): within-2-semitones rate +
+          contour correlation - isolates pitch error from timing error.
+  bpm   : beatgrid.detect_bpm (on the instrumental stem, like main.py) vs the
+          gold #BPM header, mod power-of-two multiple.
+
+Stages usdx-autochart replays that USKMaker doesn't have (MMS_FA forced
+alignment, syllabify_es proportional spread) are deliberately dropped.
+
+Resumable: the run dir is keyed by n+seed (or the seed set); songs with an
+existing result/error JSON are skipped. Demucs stems, alignment, and pitch are
+cached per song under <run_dir>/cache/<slug>/ - Demucs is nondeterministic
+(randomized shifts), so FIXED stems are what make A/B comparisons between code
+versions meaningful. Gold onsets are themselves ~50 ms-grid quantized and
+stylistic - differences below ~25-50 ms are noise, not signal.
+
+  python eval/library_replay.py --n 20 --seed 0
+  python eval/library_replay.py --seed-set eval/seed_set.json
+  python eval/library_replay.py --n 20 --seed 0 --aggregate-only
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import difflib
+import json
+import math
+import os
+import random
+import re
+import shutil
+import statistics
+import sys
+import unicodedata
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parents[0]))  # python-sidecar root, for `pipeline`
+sys.path.insert(0, str(_HERE))             # eval dir, for sibling usdx_parse
+
+import usdx_parse  # noqa: E402
+
+
+# gold-chart #LANGUAGE header -> whisper language code; unmapped -> song skipped
+LANG_CODES = {
+    "spanish": "es", "español": "es", "espanol": "es",
+    "english": "en", "french": "fr", "français": "fr", "german": "de",
+    "deutsch": "de", "italian": "it", "portuguese": "pt", "português": "pt",
+    "japanese": "ja", "korean": "ko", "chinese": "zh",
+    "catalan": "ca", "catalán": "ca", "gallego": "gl",
+    "dutch": "nl", "swedish": "sv", "finnish": "fi", "russian": "ru",
+    "polish": "pl", "turkish": "tr", "latin": "la",
+}
+
+
+def log(msg: str) -> None:
+    print(f"[replay] {msg}", flush=True)
+
+
+def slugify(name: str) -> str:
+    return re.sub(r"[^A-Za-z0-9]+", "_", name).strip("_")[:80]
+
+
+def scan_library(lib: str) -> list[dict]:
+    """Folders with exactly one .mp3 and a gold (non-MULTI) .txt."""
+    songs = []
+    for name in sorted(os.listdir(lib)):
+        d = os.path.join(lib, name)
+        if not os.path.isdir(d):
+            continue
+        try:
+            files = os.listdir(d)
+        except OSError:
+            continue
+        mp3s = [f for f in files if f.lower().endswith(".mp3")]
+        txts = [f for f in files if f.lower().endswith(".txt")]
+        golds = [f for f in txts if "[multi]" not in f.lower()]
+        if len(mp3s) != 1 or not golds:
+            continue
+        songs.append({
+            "name": name,
+            "mp3": os.path.join(d, mp3s[0]),
+            "gold": os.path.join(d, sorted(golds, key=len)[0]),
+        })
+    return songs
+
+
+# ---------- gold chart -> time-domain events ----------
+
+def _key(word: str) -> str:
+    w = unicodedata.normalize("NFKD", word.lower())
+    w = "".join(c for c in w if not unicodedata.combining(c))
+    return re.sub(r"[^a-z0-9]", "", w)
+
+
+def gold_words(chart) -> list[dict]:
+    """Time-domain words from a parsed gold chart. A note is a syllable; a new
+    word starts at a line break, after a note with trailing space, or on a note
+    with leading space. '~'/empty notes are holds extending the previous
+    syllable. Each word: {text, start, end, line_index}."""
+    words: list[dict] = []
+    for li, line in enumerate(chart.lines):
+        word = None
+        prev_trail = False
+        for n in line.notes:
+            raw, txt = n.text, n.text.strip()
+            s = chart.beat_to_time(n.start_beat)
+            e = chart.beat_to_time(n.start_beat + n.duration)
+            if txt in ("~", ""):  # hold continuation
+                if word:
+                    word["end"] = max(word["end"], e)
+                if raw:
+                    prev_trail = raw[-1:].isspace()
+                continue
+            if word is None or prev_trail or raw[:1].isspace():
+                if word:
+                    words.append(word)
+                word = {"text": txt, "start": s, "end": e, "line_index": li}
+            else:
+                word["text"] += txt
+                word["end"] = max(word["end"], e)
+            prev_trail = raw[-1:].isspace() if raw else False
+        if word:
+            words.append(word)
+    return words
+
+
+def gold_notes(chart) -> list[tuple]:
+    """Pitched notes as (start_s, end_s, pitch); freestyle/rap carry no pitch."""
+    out = []
+    for line in chart.lines:
+        for n in line.notes:
+            if n.kind in ("normal", "golden"):
+                out.append((chart.beat_to_time(n.start_beat),
+                            chart.beat_to_time(n.start_beat + n.duration),
+                            n.pitch))
+    return out
+
+
+def gold_lyrics_text(gwords: list[dict]) -> str:
+    """Plain lyrics (one line per gold chart line) - align.py's input format."""
+    by_line: dict[int, list[str]] = defaultdict(list)
+    for w in gwords:
+        by_line[w["line_index"]].append(w["text"])
+    return "\n".join(" ".join(by_line[li]) for li in sorted(by_line)) + "\n"
+
+
+# ---------- matching + metrics ----------
+
+def match_words(gold: list[dict], hyp: list[dict]) -> list[tuple[int, int]]:
+    """Text-match gold<->hypothesis words (difflib on normalized keys).
+    Returns (gold_idx, hyp_idx) pairs."""
+    ga = [(i, _key(w["text"])) for i, w in enumerate(gold)]
+    ha = [(j, _key(w["text"])) for j, w in enumerate(hyp)]
+    ga = [(i, k) for i, k in ga if k]
+    ha = [(j, k) for j, k in ha if k]
+    sm = difflib.SequenceMatcher(a=[k for _, k in ga], b=[k for _, k in ha],
+                                 autojunk=False)
+    pairs = []
+    for tag, i1, i2, j1, j2 in sm.get_opcodes():
+        if tag not in ("equal", "replace"):
+            continue
+        for k in range(min(i2 - i1, j2 - j1)):
+            if tag == "replace" and difflib.SequenceMatcher(
+                    a=ga[i1 + k][1], b=ha[j1 + k][1]).ratio() < 0.5:
+                continue
+            pairs.append((ga[i1 + k][0], ha[j1 + k][0]))
+    return pairs
+
+
+def _err_stats(errs: list[float]) -> dict | None:
+    if not errs:
+        return None
+    a = sorted(abs(x) for x in errs)
+    return {"n": len(a),
+            "median_ms": round(a[len(a) // 2] * 1000, 1),
+            "mae_ms": round(sum(a) / len(a) * 1000, 1),
+            "p90_ms": round(a[int(0.9 * (len(a) - 1))] * 1000, 1),
+            "bias_ms": round(statistics.median(errs) * 1000, 1)}
+
+
+def timing_stats(gold: list[dict], hyp: list[dict],
+                 pairs: list[tuple[int, int]]) -> dict:
+    onset = [hyp[j]["start"] - gold[i]["start"] for i, j in pairs]
+    end = [hyp[j]["end"] - gold[i]["end"] for i, j in pairs]
+    # within_1s is the headline number from previous manual validations
+    # (~65-90% is the normal band on good songs). recall is ~1 by
+    # construction here (align_lyrics_to_audio emits one timing per lyric
+    # word) - it only drops when _key() filters out unmatchable tokens.
+    within_1s = (round(sum(1 for x in onset if abs(x) <= 1.0) / len(onset), 3)
+                 if onset else 0.0)
+    return {"recall": round(len(pairs) / len(gold), 3) if gold else 0.0,
+            "within_1s": within_1s,
+            "onset": _err_stats(onset), "end": _err_stats(end)}
+
+
+def pitch_metrics(notes: list[tuple], times, hz, voicing) -> dict:
+    """SwiftF0 voiced-median MIDI inside *gold* note boundaries vs gold pitch
+    (relative, medians subtracted)."""
+    gold_p, est_m = [], []
+    for s, e, p in notes:
+        mask = (times >= s) & (times < e) & voicing & (hz > 0)
+        if mask.sum() < 2:
+            continue
+        est_m.append(69.0 + 12.0 * math.log2(float(np.median(hz[mask])) / 440.0))
+        gold_p.append(p)
+    out = {"n_notes": len(notes), "n_scored": len(gold_p),
+           "coverage": round(len(gold_p) / len(notes), 3) if notes else 0.0}
+    if len(gold_p) >= 10:
+        g = np.array(gold_p, float)
+        c = np.array(est_m, float)
+        g -= np.median(g)
+        c -= np.median(c)
+        out["within_2st"] = round(float(np.mean(np.abs(g - c) <= 2)), 3)
+        out["contour_corr"] = (round(float(np.corrcoef(g, c)[0, 1]), 3)
+                               if g.std() and c.std() else 0.0)
+    return out
+
+
+def bpm_metric(est: float | None, file_bpm: float) -> dict | None:
+    """Deviation of the estimate from the gold #BPM, mod power-of-two multiple
+    (gold file BPMs are often the musical BPM x2/x4 for grid fineness)."""
+    if not est or est <= 0 or not file_bpm:
+        return None
+    k = file_bpm / est
+    p = 2.0 ** round(math.log2(k))
+    return {"est": round(est, 1), "file_bpm": file_bpm, "mult": p,
+            "dev": round(abs(k / p - 1), 4)}
+
+
+# ---------- per-song run (cached, resumable) ----------
+
+def _cached_stems(mp3: str, cache: Path, device: str) -> tuple[Path, Path]:
+    """Demucs stems, separated once and cached: nondeterministic between runs,
+    so a fixed stem is what makes cross-run comparisons meaningful."""
+    vocals = cache / "vocals.wav"
+    instrumental = cache / "no_vocals.wav"
+    if vocals.exists() and instrumental.exists():
+        return vocals, instrumental
+    from pipeline.separate import separate_vocals
+    log("  demucs...")
+    tmp = cache / "demucs_tmp"
+    stems = separate_vocals(Path(mp3), tmp, device=device)
+    shutil.move(str(stems.vocals), str(vocals))
+    shutil.move(str(stems.instrumental), str(instrumental))
+    shutil.rmtree(tmp, ignore_errors=True)
+    return vocals, instrumental
+
+
+def _timings_to_dicts(timings) -> list[dict]:
+    return [{"text": t.word, "start": t.start, "end": t.end,
+             "source": t.source, "score": t.score} for t in timings]
+
+
+def _cached_alignment(stem: Path, cache: Path, gwords: list[dict],
+                      language: str, device: str) -> dict:
+    """align.align_lyrics_to_audio on the cached stem, mirroring main.py's
+    Etapa 4b rescue: if >10% of words end up interpolated, isolate the lead
+    vocal and re-align, keeping whichever result has fewer interpolated words
+    (the pipeline's internal quality signal - no ground truth needed)."""
+    aj = cache / "align.json"
+    if aj.exists():
+        with open(aj, encoding="utf-8") as f:
+            return json.load(f)
+
+    from pipeline.align import align_lyrics_to_audio, alignment_stats
+
+    lyrics_path = cache / "lyrics.txt"
+    lyrics_path.write_text(gold_lyrics_text(gwords), encoding="utf-8")
+
+    log(f"  align (whisperx, lang={language})...")
+    timings = align_lyrics_to_audio(stem, lyrics_path, language=language,
+                                    device=device)
+    interp = alignment_stats(timings)["by_source"]["interpolated"]
+    interp_frac = interp / max(len(timings), 1)
+
+    rescue = {"tried": False, "won": False, "base_interp_frac": round(interp_frac, 3)}
+    if interp_frac > 0.10:
+        rescue["tried"] = True
+        log(f"  rescue: {100 * interp_frac:.0f}% interpolated, isolating lead vocal...")
+        try:
+            from pipeline.separate import isolate_lead_vocal
+            lead = cache / "lead_vocals.wav"
+            if not lead.exists():
+                lead = isolate_lead_vocal(stem, cache)
+            retry = align_lyrics_to_audio(lead, lyrics_path, language=language,
+                                          device=device)
+            retry_interp = alignment_stats(retry)["by_source"]["interpolated"]
+            rescue["lead_interp_frac"] = round(retry_interp / max(len(retry), 1), 3)
+            if retry_interp < interp:
+                rescue["won"] = True
+                timings = retry
+        except Exception as e:  # noqa: BLE001 - non-fatal, same as main.py
+            rescue["error"] = repr(e)
+            log(f"  rescue failed (non-fatal): {e!r}")
+
+    stats = alignment_stats(timings)
+    result = {"words": _timings_to_dicts(timings),
+              "interp_frac": round(stats["by_source"]["interpolated"]
+                                   / max(stats["total"], 1), 3),
+              "rescue": rescue}
+    with open(aj, "w", encoding="utf-8") as f:
+        json.dump(result, f, ensure_ascii=False)
+    return result
+
+
+def _cached_pitch(stem: Path, cache: Path):
+    pz = cache / "pitch.npz"
+    if pz.exists():
+        d = np.load(pz)
+        return d["t"], d["hz"], d["voicing"].astype(bool)
+    import soundfile as sf
+    from pipeline.pitch import PitchExtractor
+    log("  pitch (SwiftF0)...")
+    duration = sf.info(str(stem)).duration
+    track = PitchExtractor().extract_word_track(str(stem), 0.0, duration)
+    np.savez_compressed(pz, t=track.timestamps, hz=track.pitch_hz,
+                        voicing=track.voicing)
+    return track.timestamps, track.pitch_hz, track.voicing
+
+
+def _run_song(song: dict, run_dir: str, slug: str, device: str) -> dict:
+    chart = usdx_parse.read_file(song["gold"])
+    gwords = gold_words(chart)
+    if len(gwords) < 30:
+        raise ValueError(f"only {len(gwords)} gold words")
+    language = LANG_CODES.get((chart.language or "").strip().lower())
+    if not language:
+        raise ValueError(f"unmapped gold #LANGUAGE {chart.language!r}")
+    notes = gold_notes(chart)
+    cache = Path(run_dir) / "cache" / slug
+    cache.mkdir(parents=True, exist_ok=True)
+
+    vocals, instrumental = _cached_stems(song["mp3"], cache, device)
+    align_res = _cached_alignment(vocals, cache, gwords, language, device)
+    times, hz, voicing = _cached_pitch(vocals, cache)
+
+    try:
+        from pipeline.beatgrid import detect_bpm
+        bpm_est = detect_bpm(instrumental).bpm
+    except Exception:  # noqa: BLE001 - informational metric
+        bpm_est = None
+
+    span = gwords[-1]["end"] - gwords[0]["start"]
+    hyp = align_res["words"]
+    pairs = match_words(gwords, hyp)
+    return {
+        "song": song["name"],
+        "lang_group": song.get("lang_group"),
+        "wpm": round(len(gwords) / (span / 60), 1) if span > 0 else None,
+        "n_gold_words": len(gwords),
+        "align": {"n_words": len(hyp),
+                  "interp_frac": align_res["interp_frac"],
+                  "rescue": align_res["rescue"],
+                  **timing_stats(gwords, hyp, pairs)},
+        "pitch": pitch_metrics(notes, times, hz, voicing),
+        "bpm": bpm_metric(bpm_est, chart.bpm),
+    }
+
+
+def run_song(song: dict, run_dir: str, device: str) -> None:
+    slug = slugify(song["name"])
+    rj = os.path.join(run_dir, "results", f"{slug}.json")
+    ej = os.path.join(run_dir, "results", f"{slug}.error.json")
+    if os.path.exists(rj) or os.path.exists(ej):
+        log(f"[skip] {song['name']} (already done)")
+        return
+    log(f"[run ] {song['name']}")
+    try:
+        res = _run_song(song, run_dir, slug, device)
+        with open(rj, "w", encoding="utf-8") as f:
+            json.dump(res, f, ensure_ascii=False, indent=1, default=float)
+    except Exception as e:  # noqa: BLE001 - one bad song must not kill the run
+        log(f"       FAILED: {e!r}")
+        with open(ej, "w", encoding="utf-8") as f:
+            json.dump({"error": repr(e)}, f)
+    try:
+        import torch
+        torch.cuda.empty_cache()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ---------- sampling ----------
+
+def build_manifest(lib: str, runs_root: str) -> list[dict]:
+    """Usable songs with lang_group + gold wpm; cached (one full-library parse)."""
+    os.makedirs(runs_root, exist_ok=True)
+    path = os.path.join(runs_root, "library_manifest.json")
+    if os.path.exists(path):
+        with open(path, encoding="utf-8") as f:
+            m = json.load(f)
+        if m.get("lib") == lib:
+            return m["songs"]
+    songs = scan_library(lib)
+    out = []
+    for i, s in enumerate(songs):
+        if i and i % 1000 == 0:
+            log(f"scanning gold charts {i}/{len(songs)}...")
+        try:
+            if usdx_parse.is_relative(s["gold"]):
+                continue
+            chart = usdx_parse.read_file(s["gold"])
+            gw = gold_words(chart)
+            if len(gw) < 30:
+                continue
+            span = gw[-1]["end"] - gw[0]["start"]
+            if span < 60:
+                continue
+            code = LANG_CODES.get((chart.language or "").strip().lower(), "other")
+            out.append({"name": s["name"], "mp3": s["mp3"], "gold": s["gold"],
+                        "lang_group": code if code in ("es", "en") else "other",
+                        "wpm": round(len(gw) / (span / 60), 1)})
+        except Exception:  # noqa: BLE001 - unparseable gold: not usable
+            continue
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump({"lib": lib, "songs": out}, f, ensure_ascii=False)
+    log(f"manifest: {len(out)} usable songs (cached at {path})")
+    return out
+
+
+def stratified_sample(manifest: list[dict], n: int, seed: int):
+    """Proportional allocation over lang_group x wpm tercile, seeded."""
+    wpms = sorted(s["wpm"] for s in manifest)
+    t1, t2 = wpms[len(wpms) // 3], wpms[2 * len(wpms) // 3]
+
+    def terc(w):
+        return 0 if w < t1 else (1 if w < t2 else 2)
+
+    strata: dict[tuple, list] = defaultdict(list)
+    for s in manifest:
+        strata[(s["lang_group"], terc(s["wpm"]))].append(s)
+    keys = sorted(strata)
+    total = len(manifest)
+    alloc = {k: max(1, round(n * len(strata[k]) / total)) for k in keys}
+    while sum(alloc.values()) > n:
+        k = max(keys, key=lambda k: alloc[k])
+        alloc[k] -= 1
+    while sum(alloc.values()) < n:
+        k = max(keys, key=lambda k: len(strata[k]) - alloc[k])
+        alloc[k] += 1
+    rng = random.Random(seed)
+    sample = []
+    for k in keys:
+        sample.extend(rng.sample(strata[k], min(alloc[k], len(strata[k]))))
+    return sample, (t1, t2)
+
+
+def seed_set_sample(seed_set_path: str, manifest: list[dict]) -> list[dict]:
+    """The curated seed set (eval/seed_set.json): songs referenced by library
+    folder name - each dev supplies audio + gold .txt locally; nothing
+    copyrighted lives in the repo."""
+    with open(seed_set_path, encoding="utf-8") as f:
+        seed_set = json.load(f)
+    by_name = {s["name"]: s for s in manifest}
+    sample = []
+    for entry in seed_set["songs"]:
+        s = by_name.get(entry["folder"])
+        if s:
+            sample.append(s)
+        else:
+            log(f"[miss] seed-set song not in library (or unusable): {entry['folder']}")
+    return sample
+
+
+# ---------- aggregation ----------
+
+FLAT_FIELDS = ["song", "lang_group", "wpm", "n_gold_words",
+               "recall", "within_1s", "onset_med_ms", "onset_mae_ms",
+               "onset_p90_ms", "bias_ms", "end_med_ms", "interp_frac",
+               "rescue_tried", "rescue_won",
+               "pitch_coverage", "pitch_within_2st", "pitch_corr",
+               "bpm_est", "bpm_mult", "bpm_dev", "error"]
+
+KEY_METRICS = ["within_1s", "onset_med_ms", "interp_frac",
+               "pitch_within_2st", "pitch_corr", "bpm_dev"]
+
+
+def _flat(r: dict) -> dict:
+    a = r.get("align") or {}
+    ao = a.get("onset") or {}
+    ae = a.get("end") or {}
+    resc = a.get("rescue") or {}
+    pi, bp = r.get("pitch") or {}, r.get("bpm") or {}
+    return {
+        "n_gold_words": r.get("n_gold_words"),
+        "recall": a.get("recall"), "within_1s": a.get("within_1s"),
+        "onset_med_ms": ao.get("median_ms"),
+        "onset_mae_ms": ao.get("mae_ms"), "onset_p90_ms": ao.get("p90_ms"),
+        "bias_ms": ao.get("bias_ms"), "end_med_ms": ae.get("median_ms"),
+        "interp_frac": a.get("interp_frac"),
+        "rescue_tried": resc.get("tried"), "rescue_won": resc.get("won"),
+        "pitch_coverage": pi.get("coverage"),
+        "pitch_within_2st": pi.get("within_2st"), "pitch_corr": pi.get("contour_corr"),
+        "bpm_est": bp.get("est"), "bpm_mult": bp.get("mult"), "bpm_dev": bp.get("dev"),
+    }
+
+
+def aggregate(sample: list[dict], run_dir: str) -> None:
+    rows = []
+    for s in sample:
+        slug = slugify(s["name"])
+        row = {"song": s["name"], "lang_group": s.get("lang_group"),
+               "wpm": s.get("wpm")}
+        rj = os.path.join(run_dir, "results", f"{slug}.json")
+        ej = os.path.join(run_dir, "results", f"{slug}.error.json")
+        if os.path.exists(rj):
+            with open(rj, encoding="utf-8") as f:
+                row.update(_flat(json.load(f)))
+        elif os.path.exists(ej):
+            with open(ej, encoding="utf-8") as f:
+                row["error"] = json.load(f).get("error")
+        else:
+            row["error"] = "not run"
+        rows.append(row)
+
+    csv_path = os.path.join(run_dir, "results.csv")
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=FLAT_FIELDS)
+        w.writeheader()
+        w.writerows(rows)
+
+    ok = [r for r in rows if r.get("recall") is not None]
+    failed = [r for r in rows if r.get("error")]
+
+    def med_line(rs, label):
+        parts = [f"  {label:24s}"]
+        for k in KEY_METRICS:
+            vals = [r[k] for r in rs if r.get(k) is not None]
+            parts.append(f"{statistics.median(vals):9.3f}" if vals else "       --")
+        print("".join(parts))
+
+    print(f"\n=== library replay summary ({len(ok)} scored, {len(failed)} failed,"
+          f" {len(rows)} total) ===")
+    print("  " + " " * 24 + "".join(f"{h:>9s}" for h in
+                                    ["w_1s", "onset", "interp", "p_2st",
+                                     "p_corr", "bpm_dev"]))
+    med_line(ok, "ALL (median)")
+    for lg in ("es", "en", "other"):
+        rs = [r for r in ok if r["lang_group"] == lg]
+        if rs:
+            med_line(rs, f"lang={lg} (n={len(rs)})")
+    rescued = [r for r in ok if r.get("rescue_tried")]
+    if rescued:
+        won = sum(1 for r in rescued if r.get("rescue_won"))
+        print(f"\n  lead-vocal rescue tried on {len(rescued)}/{len(ok)} songs, won {won}")
+    bpm_all = [r for r in ok if r.get("bpm_dev") is not None]
+    bpm_good = [r for r in bpm_all if r["bpm_dev"] < 0.02]
+    if bpm_all:
+        print(f"  BPM estimate within 2% of gold (mod octave): "
+              f"{len(bpm_good)}/{len(bpm_all)}")
+    for r in failed:
+        print(f"  FAILED: {r['song']}: {r['error']}")
+    print(f"\n  full table: {csv_path}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--lib", default=r"D:\Canciones Karaoke")
+    ap.add_argument("--n", type=int, default=20)
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--seed-set", default=None,
+                    help="path to a curated seed-set JSON (eval/seed_set.json); "
+                         "overrides --n/--seed sampling")
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--aggregate-only", action="store_true")
+    args = ap.parse_args()
+
+    runs_root = str(_HERE.parents[0] / "eval_runs")
+    manifest = build_manifest(args.lib, runs_root)
+    if not manifest:
+        return 2
+
+    if args.seed_set:
+        sample = seed_set_sample(args.seed_set, manifest)
+        run_dir = os.path.join(runs_root, "replay-seedset")
+    else:
+        sample, _ = stratified_sample(manifest, args.n, args.seed)
+        run_dir = os.path.join(runs_root, f"replay-n{args.n}-seed{args.seed}")
+    counts = ", ".join(
+        f"{lg}={sum(1 for s in sample if s['lang_group'] == lg)}"
+        for lg in ("es", "en", "other"))
+    log(f"sample: {len(sample)} songs ({counts})")
+
+    for sub in ("results", "cache"):
+        os.makedirs(os.path.join(run_dir, sub), exist_ok=True)
+
+    if not args.aggregate_only:
+        for i, song in enumerate(sample, 1):
+            log(f"[{i}/{len(sample)}]")
+            run_song(song, run_dir, args.device)
+
+    aggregate(sample, run_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python-sidecar/eval/seed_set.json
+++ b/python-sidecar/eval/seed_set.json
@@ -1,0 +1,61 @@
+{
+  "comment": "Curated gold seed set agreed on upstream issue #2. Referenced by library folder name ONLY - no audio or charts live in the repo; each dev supplies the files locally (folder = 'Artist - Title' with .mp3 + gold .txt). BPM range 184-417 (fine-grid hand charts).",
+  "songs": [
+    {
+      "folder": "ABBA - Dancing Queen",
+      "artist": "ABBA",
+      "title": "Dancing Queen",
+      "language": "en",
+      "style": "pop (SingStar ABBA)",
+      "stresses": "clean melismatic baseline; layered backing harmonies (lead-vocal rescue candidate)"
+    },
+    {
+      "folder": "3 Doors Down - Kryptonite",
+      "artist": "3 Doors Down",
+      "title": "Kryptonite",
+      "language": "en",
+      "style": "rock (SingStar Pop USA)",
+      "stresses": "syllabic rock, contrast to melisma"
+    },
+    {
+      "folder": "50 Cent feat Justin Timberlake & Timbaland - Ayo Technology",
+      "artist": "50 Cent feat Justin Timberlake & Timbaland",
+      "title": "Ayo Technology",
+      "language": "en",
+      "style": "pop-rock / rap",
+      "stresses": "fast rap + freestyle notes -> Whisper word-recall"
+    },
+    {
+      "folder": "Vicente Fernández - Estos celos",
+      "artist": "Vicente Fernández",
+      "title": "Estos celos",
+      "language": "es",
+      "style": "ranchera ballad",
+      "stresses": "held vowels / melisma / elongation"
+    },
+    {
+      "folder": "Morat & Juanes - Besos en guerra",
+      "artist": "Morat & Juanes",
+      "title": "Besos en guerra",
+      "language": "es",
+      "style": "pop",
+      "stresses": "elaborate mid-tempo, dense; stacked backing harmonies (lead-vocal rescue candidate)"
+    },
+    {
+      "folder": "Bad Bunny y Chencho Corleone - Me porto bonito",
+      "artist": "Bad Bunny & Chencho Corleone",
+      "title": "Me porto bonito",
+      "language": "es",
+      "style": "reggaeton",
+      "stresses": "duet P1/P2 ([MULTI] gold -> evaluate.py --duet, not the replay) + fast delivery"
+    },
+    {
+      "folder": "Abingdon boys school - Innocent sorrow (TV)",
+      "artist": "Abingdon boys school",
+      "title": "Innocent sorrow (TV)",
+      "language": "ja",
+      "style": "anime opening (short TV cut)",
+      "stresses": "romaji, fast syllabic"
+    }
+  ]
+}

--- a/python-sidecar/eval/seed_set.json
+++ b/python-sidecar/eval/seed_set.json
@@ -47,7 +47,7 @@
       "title": "Me porto bonito",
       "language": "es",
       "style": "reggaeton",
-      "stresses": "duet P1/P2 ([MULTI] gold -> evaluate.py --duet, not the replay) + fast delivery"
+      "stresses": "fast delivery; [MULTI] duet gold scored flattened (single-player: one voice covers both parts) - per-singer scoring returns if duet generation lands"
     },
     {
       "folder": "Abingdon boys school - Innocent sorrow (TV)",

--- a/python-sidecar/eval/usdx_parse.py
+++ b/python-sidecar/eval/usdx_parse.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+"""Parse a UltraStar .txt chart into a Chart (gold-chart reader for the eval
+harness). Ported from usdx-autochart (MIT, Alejololer/usdx-autochart) --
+USKMaker only had writers (pipeline/ultrastar_writer.py, rust-core) until now.
+
+Mirrors the grammar in USDX's src/base/USong.pas (ReadTXTHeader + LoadOpenedSong):
+  header lines start with '#TAG:value'
+  note lines:   <type> <startBeat> <durationBeats> <pitch> <lyric>
+  break lines:  - <startBeat> [relativeOffset]
+  duet tracks:  P1 / P2     end marker: E
+
+Timing model (same formula validated against D:\\Canciones Karaoke charts):
+  time_s = GAP/1000 + beat * 60 / (fileBPM * 4)
+Note lyrics are NOT stripped: trailing/leading spaces mark word boundaries.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+# USDX note type -> leading character (see USong.pas / UMusic.pas TNoteType)
+NOTE_CHARS = {
+    "normal": ":",
+    "golden": "*",
+    "freestyle": "F",
+    "rap": "R",
+    "rapgolden": "G",
+}
+CHAR_TO_KIND = {v: k for k, v in NOTE_CHARS.items()}
+
+
+@dataclass
+class Note:
+    start_beat: int
+    duration: int          # in beats
+    pitch: int             # integer semitone, 0 = C4
+    text: str              # raw lyric, spaces preserved (word boundaries!)
+    kind: str = "normal"   # key of NOTE_CHARS
+
+
+@dataclass
+class Line:
+    """A sentence. `break_beat` is the beat on the '-' break before it."""
+    notes: List[Note] = field(default_factory=list)
+    break_beat: Optional[int] = None
+
+
+@dataclass
+class Chart:
+    title: str
+    artist: str
+    bpm: float                  # the raw #BPM header value (the "file BPM")
+    gap_ms: float               # #GAP in milliseconds
+    audio: str
+    lines: List[Line] = field(default_factory=list)
+    # Duet: with keep_tracks=True, one list of Lines per singer (P1/P2 blocks);
+    # `lines` is then empty.
+    tracks: Optional[List[List[Line]]] = None
+    p1: Optional[str] = None
+    p2: Optional[str] = None
+    language: Optional[str] = None
+    genre: Optional[str] = None
+    year: Optional[int] = None
+
+    def seconds_per_beat(self) -> float:
+        return 15.0 / self.bpm  # 60 / (fileBPM * 4)
+
+    def beat_to_time(self, beat: int) -> float:
+        return self.gap_ms / 1000.0 + beat * self.seconds_per_beat()
+
+
+def _to_float(value: str) -> float:
+    # USDX StrToFloatI18n accepts both ',' and '.' as the decimal separator.
+    return float(value.strip().replace(",", "."))
+
+
+def parse(text: str, *, keep_tracks: bool = False) -> Chart:
+    """Parse a chart. By default duet ``P1``/``P2`` markers are flattened into a
+    single ``Chart.lines`` (enough for the flattened time-domain ``evaluate``).
+    With ``keep_tracks=True`` the P-blocks are kept as separate ``Chart.tracks``
+    (used by ``evaluate_duet`` to score per-singer attribution)."""
+    header = {}
+    lines: List[Line] = []
+    tracks: List[List[Line]] = []
+    cur = Line()  # first sentence has no preceding break
+    started = False
+
+    def target() -> List[Line]:
+        return tracks[-1] if (keep_tracks and tracks) else lines
+
+    def flush():
+        nonlocal cur
+        if cur.notes or cur.break_beat is not None:
+            target().append(cur)
+        cur = Line()
+
+    for raw in text.splitlines():
+        line = raw.rstrip("\n")
+        if not line.strip():
+            continue
+        if line.startswith("#") and not started:
+            if ":" in line:
+                tag, _, val = line[1:].partition(":")
+                header[tag.strip().upper()] = val.strip()
+            continue
+
+        token = line[0]
+        if token in CHAR_TO_KIND:
+            started = True
+            # 4 fields + remainder lyric; the lyric may contain/end with spaces
+            m = re.match(r"^(.)\s+(-?\d+)\s+(\d+)\s+(-?\d+)\s?(.*)$", line)
+            if not m:
+                continue
+            _, sb, dur, pitch, lyric = m.groups()
+            cur.notes.append(
+                Note(int(sb), int(dur), int(pitch), lyric, CHAR_TO_KIND[token])
+            )
+        elif token == "-":
+            started = True
+            parts = line.split()
+            flush()
+            cur.break_beat = int(parts[1]) if len(parts) > 1 else None
+        elif token in ("E",):
+            break
+        elif token in ("P", "p"):
+            # duet track marker: community charts use "P 1"/"P 2", generated
+            # ones "P1"/"P2" - both key on the first char.
+            started = True
+            if keep_tracks:
+                flush()
+                tracks.append([])
+            continue
+
+    flush()
+
+    audio = header.get("AUDIO") or header.get("MP3") or ""
+    p1 = header.get("DUETSINGERP1") or header.get("P1")
+    p2 = header.get("DUETSINGERP2") or header.get("P2")
+    keep = keep_tracks and bool(tracks)
+    return Chart(
+        title=header.get("TITLE", ""),
+        artist=header.get("ARTIST", ""),
+        bpm=_to_float(header["BPM"]) if "BPM" in header else 0.0,
+        gap_ms=_to_float(header.get("GAP", "0")),
+        audio=audio,
+        lines=[] if keep else lines,
+        tracks=tracks if keep else None,
+        p1=p1,
+        p2=p2,
+        language=header.get("LANGUAGE"),
+        genre=header.get("GENRE"),
+        year=int(header["YEAR"]) if header.get("YEAR", "").isdigit() else None,
+    )
+
+
+def is_relative(path: str) -> bool:
+    """#RELATIVE charts restart beats per line; this parser doesn't model that,
+    so callers must skip them."""
+    try:
+        with open(path, "rb") as f:
+            head = f.read(4096).decode("latin-1")
+        return bool(re.search(r"(?im)^#RELATIVE\s*:\s*yes", head))
+    except OSError:
+        return False
+
+
+def read_file(path: str, *, keep_tracks: bool = False) -> Chart:
+    # Community charts are frequently CP1252; fall through from utf-8.
+    for enc in ("utf-8-sig", "cp1252", "latin-1"):
+        try:
+            with open(path, "r", encoding=enc) as f:
+                return parse(f.read(), keep_tracks=keep_tracks)
+        except UnicodeDecodeError:
+            continue
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        return parse(f.read(), keep_tracks=keep_tracks)

--- a/python-sidecar/eval/usdx_parse.py
+++ b/python-sidecar/eval/usdx_parse.py
@@ -7,7 +7,7 @@ Mirrors the grammar in USDX's src/base/USong.pas (ReadTXTHeader + LoadOpenedSong
   header lines start with '#TAG:value'
   note lines:   <type> <startBeat> <durationBeats> <pitch> <lyric>
   break lines:  - <startBeat> [relativeOffset]
-  duet tracks:  P1 / P2     end marker: E
+  duet tracks:  P1 / P2 (flattened - see parse())     end marker: E
 
 Timing model (same formula validated against D:\\Canciones Karaoke charts):
   time_s = GAP/1000 + beat * 60 / (fileBPM * 4)
@@ -54,11 +54,6 @@ class Chart:
     gap_ms: float               # #GAP in milliseconds
     audio: str
     lines: List[Line] = field(default_factory=list)
-    # Duet: with keep_tracks=True, one list of Lines per singer (P1/P2 blocks);
-    # `lines` is then empty.
-    tracks: Optional[List[List[Line]]] = None
-    p1: Optional[str] = None
-    p2: Optional[str] = None
     language: Optional[str] = None
     genre: Optional[str] = None
     year: Optional[int] = None
@@ -75,24 +70,21 @@ def _to_float(value: str) -> float:
     return float(value.strip().replace(",", "."))
 
 
-def parse(text: str, *, keep_tracks: bool = False) -> Chart:
-    """Parse a chart. By default duet ``P1``/``P2`` markers are flattened into a
-    single ``Chart.lines`` (enough for the flattened time-domain ``evaluate``).
-    With ``keep_tracks=True`` the P-blocks are kept as separate ``Chart.tracks``
-    (used by ``evaluate_duet`` to score per-singer attribution)."""
+def parse(text: str) -> Chart:
+    """Parse a chart. Duet ``P1``/``P2`` markers are flattened into a single
+    ``Chart.lines`` - USKMaker generates single-track charts only today, and a
+    flattened [MULTI] gold is exactly what a single player sings when covering
+    both parts, so the time-domain ``evaluate`` compares against that. If duet
+    generation lands later, re-port usdx-autochart's ``keep_tracks`` mode."""
     header = {}
     lines: List[Line] = []
-    tracks: List[List[Line]] = []
     cur = Line()  # first sentence has no preceding break
     started = False
-
-    def target() -> List[Line]:
-        return tracks[-1] if (keep_tracks and tracks) else lines
 
     def flush():
         nonlocal cur
         if cur.notes or cur.break_beat is not None:
-            target().append(cur)
+            lines.append(cur)
         cur = Line()
 
     for raw in text.splitlines():
@@ -124,30 +116,21 @@ def parse(text: str, *, keep_tracks: bool = False) -> Chart:
         elif token in ("E",):
             break
         elif token in ("P", "p"):
-            # duet track marker: community charts use "P 1"/"P 2", generated
-            # ones "P1"/"P2" - both key on the first char.
+            # duet track marker ("P 1"/"P1") - notes keep absolute beats, so
+            # just keep appending: the tracks interleave when time-sorted.
             started = True
-            if keep_tracks:
-                flush()
-                tracks.append([])
             continue
 
     flush()
 
     audio = header.get("AUDIO") or header.get("MP3") or ""
-    p1 = header.get("DUETSINGERP1") or header.get("P1")
-    p2 = header.get("DUETSINGERP2") or header.get("P2")
-    keep = keep_tracks and bool(tracks)
     return Chart(
         title=header.get("TITLE", ""),
         artist=header.get("ARTIST", ""),
         bpm=_to_float(header["BPM"]) if "BPM" in header else 0.0,
         gap_ms=_to_float(header.get("GAP", "0")),
         audio=audio,
-        lines=[] if keep else lines,
-        tracks=tracks if keep else None,
-        p1=p1,
-        p2=p2,
+        lines=lines,
         language=header.get("LANGUAGE"),
         genre=header.get("GENRE"),
         year=int(header["YEAR"]) if header.get("YEAR", "").isdigit() else None,
@@ -165,13 +148,13 @@ def is_relative(path: str) -> bool:
         return False
 
 
-def read_file(path: str, *, keep_tracks: bool = False) -> Chart:
+def read_file(path: str) -> Chart:
     # Community charts are frequently CP1252; fall through from utf-8.
     for enc in ("utf-8-sig", "cp1252", "latin-1"):
         try:
             with open(path, "r", encoding=enc) as f:
-                return parse(f.read(), keep_tracks=keep_tracks)
+                return parse(f.read())
         except UnicodeDecodeError:
             continue
     with open(path, "r", encoding="utf-8", errors="replace") as f:
-        return parse(f.read(), keep_tracks=keep_tracks)
+        return parse(f.read())

--- a/python-sidecar/tests/test_eval_logic.py
+++ b/python-sidecar/tests/test_eval_logic.py
@@ -128,27 +128,18 @@ def test_identical_charts_score_perfect():
     assert m["pitch_within_2st_rate"] == 1.0
 
 
-def test_duet_pairing_and_assignment():
-    chart = usdx_parse.parse(DUET_CHART, keep_tracks=True)
-    assert chart.tracks is not None and len(chart.tracks) == 2
-    assert chart.p1 == "Ana" and chart.p2 == "Bruno"
-    # chart idêntico contra si mesmo: pareamento direto, atribuição perfeita
-    m = evaluate.evaluate_duet(chart, chart)
-    assert m["duet"] is True
-    assert m["pairing"] == "direct"
-    assert m["singer_assignment_accuracy"] == 1.0
-    # com os tracks trocados no "gerado", o melhor pareamento é o swap
-    swapped = usdx_parse.parse(DUET_CHART, keep_tracks=True)
-    swapped.tracks = [swapped.tracks[1], swapped.tracks[0]]
-    m2 = evaluate.evaluate_duet(swapped, chart)
-    assert m2["pairing"] == "swap"
-    assert m2["singer_assignment_accuracy"] == 1.0
-
-
-def test_duet_requires_two_tracks_both_sides():
-    flat = usdx_parse.parse(SYNTHETIC_CHART)
-    duet = usdx_parse.parse(DUET_CHART, keep_tracks=True)
-    assert evaluate.evaluate_duet(flat, duet) == {"duet": False}
+def test_duet_chart_flattens_to_single_player():
+    # avaliação é single-player por enquanto (USKMaker só gera 1 track):
+    # um gold [MULTI] achata P1+P2 em ordem de tempo - o que um jogador
+    # sozinho canta cobrindo as duas partes. Se/quando geração de dueto
+    # existir, re-portar o keep_tracks/evaluate_duet do usdx-autochart.
+    chart = usdx_parse.parse(DUET_CHART)
+    all_notes = [n for l in chart.lines for n in l.notes]
+    assert len(all_notes) == 4  # as duas partes presentes, nenhuma perdida
+    flat = evaluate._flatten(chart)
+    assert [t.text for t in flat] == ["la", "la", "na", "na"]
+    # ordenado no tempo mesmo vindo de blocos P1/P2 separados
+    assert all(a.start <= b.start for a, b in zip(flat, flat[1:]))
 
 
 def test_song_data_loader_matches_txt_semantics():

--- a/python-sidecar/tests/test_eval_logic.py
+++ b/python-sidecar/tests/test_eval_logic.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+"""
+Testes da lógica pura do harness de avaliação (eval/) - sem GPU/modelo:
+parser de .txt UltraStar, segmentação de palavras do chart gold, matching
+por onset, avaliação duet e o loader de song_data.json.
+
+Rodar:  python tests/test_eval_logic.py   (ou python -m pytest tests/ -v)
+"""
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT))
+sys.path.insert(0, str(_ROOT / "eval"))
+
+import usdx_parse
+import evaluate
+from library_replay import gold_words, match_words, timing_stats
+
+SYNTHETIC_CHART = """#TITLE:Test Song
+#ARTIST:Tester
+#LANGUAGE:Spanish
+#BPM:300,5
+#GAP:1000
+#MP3:test.mp3
+: 0 4 5 Ho
+: 4 4 5 la 
+: 8 4 7 mun
+: 12 4 7 do
+- 20
+: 24 4 9  bri
+: 28 8 9 llo
+: 36 4 0 ~
+E
+: 99 9 9 depois do E deve ser ignorado
+"""
+
+DUET_CHART = """#TITLE:Duet
+#ARTIST:Two
+#BPM:240
+#GAP:0
+#DUETSINGERP1:Ana
+#DUETSINGERP2:Bruno
+P 1
+: 0 4 5 la
+: 4 4 5 la
+P 2
+: 16 4 12 na
+: 20 4 12 na
+E
+"""
+
+
+def test_parse_headers_and_timing():
+    chart = usdx_parse.parse(SYNTHETIC_CHART)
+    assert chart.title == "Test Song"
+    assert chart.artist == "Tester"
+    assert chart.language == "Spanish"
+    assert chart.bpm == 300.5  # vírgula decimal (StrToFloatI18n) aceita
+    assert chart.gap_ms == 1000.0
+    # fórmula oficial: time = GAP/1000 + beat * 60 / (BPM*4)
+    assert abs(chart.beat_to_time(0) - 1.0) < 1e-9
+    assert abs(chart.beat_to_time(4) - (1.0 + 4 * 15.0 / 300.5)) < 1e-9
+
+
+def test_parse_notes_breaks_and_end_marker():
+    chart = usdx_parse.parse(SYNTHETIC_CHART)
+    assert len(chart.lines) == 2  # quebra "- 20" separa as frases
+    assert [n.text for n in chart.lines[0].notes] == ["Ho", "la ", "mun", "do"]
+    # espaços NÃO são aparados - marcam fronteira de palavra
+    assert chart.lines[0].notes[1].text.endswith(" ")
+    assert chart.lines[1].break_beat == 20
+    # tudo depois do E é ignorado
+    total_notes = sum(len(l.notes) for l in chart.lines)
+    assert total_notes == 7
+
+
+def test_gold_words_segmentation():
+    chart = usdx_parse.parse(SYNTHETIC_CHART)
+    words = gold_words(chart)
+    # "Ho"+"la " -> "Hola"; "mun"+"do" -> "mundo"; " bri"+"llo"+"~" -> "brillo"
+    assert [w["text"] for w in words] == ["Hola", "mundo", "brillo"]
+    # o hold "~" estende o fim da palavra até o beat 40
+    brillo = words[2]
+    assert abs(brillo["end"] - chart.beat_to_time(40)) < 1e-9
+    # início da palavra vem do primeiro beat dela
+    assert abs(brillo["start"] - chart.beat_to_time(24)) < 1e-9
+
+
+def test_match_words_normalizes_accents_and_case():
+    gold = [{"text": "Corazón"}, {"text": "partío"}, {"text": "ya"}]
+    hyp = [{"text": "corazon"}, {"text": "partio"}, {"text": "ya"}]
+    pairs = match_words(gold, hyp)
+    assert pairs == [(0, 0), (1, 1), (2, 2)]
+
+
+def test_timing_stats_within_1s():
+    gold = [{"text": "a", "start": 0.0, "end": 0.5},
+            {"text": "b", "start": 10.0, "end": 10.5},
+            {"text": "c", "start": 20.0, "end": 20.5}]
+    hyp = [{"text": "a", "start": 0.3, "end": 0.8},    # dentro de 1s
+           {"text": "b", "start": 11.5, "end": 12.0},  # fora de 1s
+           {"text": "c", "start": 20.9, "end": 21.4}]  # dentro de 1s
+    stats = timing_stats(gold, hyp, [(0, 0), (1, 1), (2, 2)])
+    assert stats["recall"] == 1.0
+    assert stats["within_1s"] == round(2 / 3, 3)
+    assert stats["onset"]["median_ms"] == 900.0
+
+
+def test_onset_match_respects_tolerance():
+    mk = lambda t: evaluate.TimedNote(t, t + 0.1, 0, "x")
+    gen = [mk(0.0), mk(1.0), mk(5.0)]
+    ref = [mk(0.05), mk(1.25), mk(9.0)]
+    pairs = evaluate._match(gen, ref, tol=0.3)
+    # 9.0 está fora da tolerância de qualquer nota gerada
+    assert len(pairs) == 2
+    starts = {(g.start, r.start) for g, r in pairs}
+    assert starts == {(0.0, 0.05), (1.0, 1.25)}
+
+
+def test_identical_charts_score_perfect():
+    chart = usdx_parse.parse(SYNTHETIC_CHART)
+    m = evaluate.evaluate(chart, chart)
+    assert m["note_count_ratio"] == 1.0
+    assert m["match_rate_vs_ref"] == 1.0
+    assert m["onset_err_ms_median"] == 0.0
+    assert m["lyric_similarity"] == 1.0
+    assert m["pitch_within_2st_rate"] == 1.0
+
+
+def test_duet_pairing_and_assignment():
+    chart = usdx_parse.parse(DUET_CHART, keep_tracks=True)
+    assert chart.tracks is not None and len(chart.tracks) == 2
+    assert chart.p1 == "Ana" and chart.p2 == "Bruno"
+    # chart idêntico contra si mesmo: pareamento direto, atribuição perfeita
+    m = evaluate.evaluate_duet(chart, chart)
+    assert m["duet"] is True
+    assert m["pairing"] == "direct"
+    assert m["singer_assignment_accuracy"] == 1.0
+    # com os tracks trocados no "gerado", o melhor pareamento é o swap
+    swapped = usdx_parse.parse(DUET_CHART, keep_tracks=True)
+    swapped.tracks = [swapped.tracks[1], swapped.tracks[0]]
+    m2 = evaluate.evaluate_duet(swapped, chart)
+    assert m2["pairing"] == "swap"
+    assert m2["singer_assignment_accuracy"] == 1.0
+
+
+def test_duet_requires_two_tracks_both_sides():
+    flat = usdx_parse.parse(SYNTHETIC_CHART)
+    duet = usdx_parse.parse(DUET_CHART, keep_tracks=True)
+    assert evaluate.evaluate_duet(flat, duet) == {"duet": False}
+
+
+def test_song_data_loader_matches_txt_semantics():
+    # mesmo conteúdo do SYNTHETIC_CHART, no formato do song_data.json que o
+    # rust-core usa pra escrever o .txt - os tempos devem bater exatamente
+    data = {
+        "title": "Test Song", "artist": "Tester", "language": "es",
+        "bpm": 300.5, "gap_ms": 1000, "mp3_filename": "test.ogg",
+        "notes": [
+            {"start_beat": 0, "duration_beats": 4, "pitch": 5, "text": "Ho", "note_type": ":", "source": "anchor"},
+            {"start_beat": 4, "duration_beats": 4, "pitch": 5, "text": "la ", "note_type": ":", "source": "anchor"},
+            {"start_beat": 8, "duration_beats": 4, "pitch": 7, "text": "mun", "note_type": ":", "source": "fuzzy"},
+            {"start_beat": 12, "duration_beats": 4, "pitch": 7, "text": "do", "note_type": ":", "source": "interpolated"},
+            {"start_beat": 24, "duration_beats": 4, "pitch": 9, "text": " bri", "note_type": ":", "source": "lrc"},
+            {"start_beat": 28, "duration_beats": 8, "pitch": 9, "text": "llo", "note_type": ":", "source": "anchor"},
+            {"start_beat": 36, "duration_beats": 4, "pitch": 0, "text": "~", "note_type": ":", "source": "anchor"},
+        ],
+        "phrase_breaks_after_index": [3],
+    }
+    chart = evaluate.chart_from_song_data(data)
+    assert len(chart.lines) == 2
+    assert len(chart.lines[0].notes) == 4 and len(chart.lines[1].notes) == 3
+    ref = usdx_parse.parse(SYNTHETIC_CHART)
+    m = evaluate.evaluate(chart, ref)
+    assert m["match_rate_vs_ref"] == 1.0
+    assert m["onset_err_ms_median"] == 0.0
+    # 1 de 7 notas interpolada
+    assert evaluate.interpolated_fraction(data) == round(1 / 7, 3)
+
+
+def test_interpolated_fraction_without_sources():
+    assert evaluate.interpolated_fraction({"notes": [{"text": "a"}]}) is None
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"[OK]   {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"[FAIL] {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} testes passaram")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
Follow-up to #3 and the plan agreed on #2: this ports the evaluation methodology from [usdx-autochart](https://github.com/Alejololer/usdx-autochart) into USKMaker, adapted to `song_data.json` and the Rust-written `.txt`. usdx-autochart is now MIT-licensed ([Alejololer/usdx-autochart@7079e7f](https://github.com/Alejololer/usdx-autochart/commit/7079e7fa1e33980421039f558f6c28eeb8aeb100)), so the port comes in cleanly under USKMaker's MIT.

Everything lives in a new `python-sidecar/eval/` dir — dev tooling only, nothing is imported by the app runtime.

## What's ported

- **`eval/usdx_parse.py`** — UltraStar `.txt` reader (USKMaker only had writers): headers, notes, breaks, cp1252/latin-1 fallback for community charts, `#RELATIVE` guard. `P1`/`P2` duet blocks are flattened in time order. Time model `time_s = GAP/1000 + beat*60/(BPM*4)`; note lyrics keep their spaces (word boundaries).
- **`eval/evaluate.py`** — time-domain chart-vs-chart scoring (note-count ratio, onset error on greedy nearest-onset matches, relative-pitch contour correlation, lyric similarity). **Adaptation:** the generated side can be a written `.txt` *or* the canonical `song_data.json`; the JSON loader also reports the interpolated-note fraction (the pipeline's internal quality signal) as a bonus metric.
- **`eval/library_replay.py`** — stage-level replay against a local gold library, with the stages **swapped for USKMaker's own**:
  - `align.align_lyrics_to_audio` on a cached Demucs stem with lyrics extracted from the gold chart → word recall + onset/end error vs gold word times, interpolated fraction, and whether the lead-vocal rescue (Etapa 4b, mirrored exactly) fired/won — the background-choir failure detector for the seed set.
  - SwiftF0 (`pitch.PitchExtractor`) voiced-median MIDI inside *gold* note bounds vs gold pitch, relative — isolates pitch error from timing error.
  - `beatgrid.detect_bpm` on the instrumental stem vs gold `#BPM`, mod power-of-two.
  - Kept from the original: resumable run dirs, per-song caching (stems are cached because **Demucs is nondeterministic** — fixed stems are what make A/B comparisons meaningful), stratified sampling (language × words-per-minute tercile), CSV + median summary.
  - **Dropped deliberately:** the MMS_FA forced-alignment and `syllabify_es` proportional-spread stages — they replay components USKMaker doesn't have.
- **`eval/seed_set.json`** — the 7 songs agreed on #2, referenced by library folder name only (audio/charts stay local; the harness logs and skips songs a dev doesn't have).
- **`tests/test_eval_logic.py`** — 10 pure-logic tests (plain `__main__` runner, repo convention): parser grammar/timing, [MULTI] flattening, gold word segmentation incl. `~` holds, onset-match tolerance, `within_1s` timing stats, and the `song_data.json` loader.

## Scope: single-player evaluation only (for now)

USKMaker doesn't generate duets, so usdx-autochart's per-singer duet scoring (`evaluate_duet`: track pairing + singer-assignment accuracy) was **not** carried over — it would be unreachable dead code here. Instead, `[MULTI]` duet golds are **flattened in time order**, which is exactly what a single player sings when covering both parts (same trick USDX players use), and scored with the same single-track metrics. The replay excludes `[MULTI]` golds entirely (interleaved voices would poison word matching). If duet generation lands later, the per-singer scoring re-ports cleanly from the same MIT source.

## Verified

- 10/10 logic tests pass (incl. flattening a real [MULTI] gold: 275 notes, chronological).
- Self-consistency: the Milo J `song_data.json` scored against its own Rust-written `.txt` → 436/436 notes matched, 0.0 ms median onset error, all similarity metrics 1.0 — the JSON loader reproduces the Rust writer's timing exactly.
- Sanity: same JSON vs an unrelated gold chart → lyric similarity 0.128, negative pitch correlation (unrelated songs score low, as they should).
- Replay smoke on my local library: the 5,557-song manifest builds and caches; stratified sample + seed-set resolution + aggregation all exercised; 2-song GPU run end-to-end, then re-run to confirm resumability (cached stems/alignment/pitch reused). The two sampled songs happened to bracket the range nicely — a French ballad at **99.3% of words within 1 s / 34.5 ms median onset / pitch corr 0.955**, and a Japanese TV cut where alignment failed outright (97.5% interpolated, rescue tried and correctly not kept) — exactly the failure the harness exists to expose.

Generated songs for the seed set + a first scored run are next — I'll post numbers on #2, including whether the rescue trigger fires on the backing-harmony songs.
